### PR TITLE
Make PrimaryKey option work with Java and Kotlin

### DIFF
--- a/Realm Object Editor/FileContentGenerator.swift
+++ b/Realm Object Editor/FileContentGenerator.swift
@@ -122,6 +122,7 @@ class FileContentGenerator {
         }
     }
     
+    
     //MARK: - Index Attributes
     func appendIndexedAttributes(indexAttributesDefination: String, forEachIndexedAttribute: String)
     {
@@ -188,6 +189,11 @@ class FileContentGenerator {
             attrDefination.replace(AttrType, by: types[attr.type.techName]!)
             var annotations = ""
             
+            if attr.isPrimaryKey{
+                if lang.primaryKeyAnnotation != nil{
+                    annotations += lang.primaryKeyAnnotation
+                }
+            }
             
             if attr.indexed{
                 if lang.indexAnnotaion != nil{

--- a/Realm Object Editor/Java.json
+++ b/Realm Object Editor/Java.json
@@ -4,6 +4,7 @@
     "toManyRelationType" : "RealmList<<!RelationshipType!>>",
     "indexAnnotaion" : "\t@Index\n",
     "ignoreAnnotaion" : "\t@Ignore\n",
+    "primaryKeyAnnotation" : "\t@PrimaryKey\n",
     "firstLineStatement" : true,
     "dataTypes": {
         "intType": "int",

--- a/Realm Object Editor/Kotlin.json
+++ b/Realm Object Editor/Kotlin.json
@@ -4,6 +4,7 @@
     "toManyRelationType" : "RealmList<<!RelationshipType!>>",
     "indexAnnotaion" : "\t@Index\n",
     "ignoreAnnotaion" : "\t@Ignore\n",
+    "primaryKeyAnnotation" : "\t@PrimaryKey\n",
     "firstLineStatement" : true,
     "dataTypes": {
         "intType": "Int",

--- a/Realm Object Editor/LangModel.swift
+++ b/Realm Object Editor/LangModel.swift
@@ -18,6 +18,7 @@ class LangModel : NSObject{
     var firstLineStatement : Bool!
 	var forEachIgnoredProperty : String!
 	var forEachIndexedAttribute : String!
+    var primaryKeyAnnotation: String!
     var getter : String!
 	var ignoredProperties : String!
     var ignoreAnnotaion : String!
@@ -52,6 +53,7 @@ class LangModel : NSObject{
 		forEachIgnoredProperty = dictionary["forEachIgnoredProperty"] as? String
 		forEachIndexedAttribute = dictionary["forEachIndexedAttribute"] as? String
         getter = dictionary["getter"] as? String
+        primaryKeyAnnotation = dictionary["primaryKeyAnnotation"] as? String
         ignoreAnnotaion = dictionary["ignoreAnnotaion"] as? String
 		ignoredProperties = dictionary["ignoredProperties"] as? String
         


### PR DESCRIPTION
Since Java and Kotlin use annotation to define PrimaryKey in model, I had updated the `appendAttributes()` to support these language.
